### PR TITLE
Revert "removing unused/maintained appVersion of chart.xml for connection-manager chart"

### DIFF
--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "api: 1.8.16, ui: 1.6.16"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 0.5.20
+version: 0.5.21
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v2
+appVersion: "api: 1.8.16, ui: 1.6.16"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
 version: 0.5.20


### PR DESCRIPTION
This reverts commit 2e90936055183e9cb5483b9977d81359ff2cbbd2.

Fix for:

```
│ Error: error validating "": error validating data: unknown object type "nil" in ConfigMap.metadata.labels.app.kubernetes.io/version
│ 
│   with helm_release.mcm-connection-manager,
│   on k8s-mcm.tf line 32, in resource "helm_release" "mcm-connection-manager":
│   32: resource "helm_release" "mcm-connection-manager" {
│ 
```