### PR TITLE
test(jira/mbp-29): implement api for providing dfsp hostname and ip-whitelist

### DIFF
--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "api: 1.8.16, ui: 1.6.16"
+appVersion: "0.6.18"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 0.5.21
+version: 0.5.22
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.6.18"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 0.5.22
+version: 0.5.23
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/README.md
+++ b/charts/connection-manager/README.md
@@ -79,7 +79,7 @@ Using standard new feature process update the following files:
   - Edit either `api.image.version` or `ui.image.version` with the latest version
 - [Chart.yaml](Chart.yaml)
   - Increment `appVersion` as appropriate
-  - Incredament `version`
+  - Increment `version`
 
 Updates to `version` are to be done in the following manner:
 

--- a/charts/connection-manager/templates/NOTES.txt
+++ b/charts/connection-manager/templates/NOTES.txt
@@ -1,0 +1,25 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named: {{ .Release.Name }}.
+
+To learn more about this release: https://github.com/modusbox/helm/releases/tag/connection-manager-{{ .Chart.Version }}
+
+To learn more about this deployment, try:
+
+  $ helm status {{ .Release.Name }}
+
+{{- if (index .Values "tests" "api" "enabled") }}
+
+Use the following command to execute Test cases:
+
+  $ helm -n {{ .Release.Namespace }} test {{ .Release.Name }}
+
+Use the following command to execute Test cases and print logs to console:
+
+  $ helm -n {{ .Release.Namespace }} test {{ .Release.Name }} --logs
+
+View Test logs with the following commands:
+
+  $ kubectl -n {{ .Release.Namespace }} logs pod/{{ include "connection-manager.fullname" . }}-api-test
+
+{{- end}}

--- a/charts/connection-manager/templates/migrations.yaml
+++ b/charts/connection-manager/templates/migrations.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migrations.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43,3 +44,4 @@ spec:
           value: {{ .Values.db.port | quote }}
       restartPolicy: OnFailure
   backoffLimit: 20
+{{- end}}

--- a/charts/connection-manager/templates/tests/api-test-runner.yaml
+++ b/charts/connection-manager/templates/tests/api-test-runner.yaml
@@ -31,21 +31,17 @@ spec:
           set +e
       env:
         - name: NVM_SCRIPT
-          value: https://raw.githubusercontent.com/nvm-sh/nvm/{{ .Values.tests.api.nvm.version }}/install.sh
+          value: {{ printf "https://raw.githubusercontent.com/nvm-sh/nvm/%s/install.sh"  .Values.tests.api.nvm.version | quote }}
         - name: TEST_SCRIPT
-          value: {{ tpl .Values.tests.api.script . }}
+          value: {{ tpl .Values.tests.api.script . | quote }}
         - name: GIT_URL
-          value: {{ tpl .Values.tests.api.git.url . }}
+          value: {{ tpl .Values.tests.api.git.url . | quote }}
         - name: GIT_TAG
-          value: {{ tpl .Values.tests.api.git.tag . }}
+          value: {{ tpl .Values.tests.api.git.tag . | quote }}
         - name: TARGET_DIR
-          value: {{ tpl .Values.tests.api.targetDirectory . }}
-        - name: APP_ENDPOINT
-          value: {{ tpl .Values.tests.api.config.appEndpoint . }}
-        - name: APP_OAUTH_CLIENT_KEY
-          value: {{ tpl .Values.tests.api.config.appOauthClientKey . }}
-        - name: APP_OAUTH_CLIENT_SECRET
-          value: {{ tpl .Values.tests.api.config.appOauthClientSecret . }}
-        - name: OAUTH2_ISSUER
-          value: {{ tpl .Values.tests.api.config.oauth2Issuer . }}
+          value: {{ tpl .Values.tests.api.targetDirectory . | quote }}
+        {{- range $name, $value := .Values.tests.api.env }}
+        - name: {{ $name }}
+          value: {{ tpl $value $ | quote }}
+        {{- end }}
 {{- end}}

--- a/charts/connection-manager/templates/tests/api-test-runner.yaml
+++ b/charts/connection-manager/templates/tests/api-test-runner.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.tests.api.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "connection-manager.fullname" . }}-api-test
+  labels:
+    app.kubernetes.io/component: test-api
+{{ include "connection-manager.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: {{ .Values.tests.api.weight | quote }}
+    helm.sh/hook-delete-policy: {{ .Values.tests.api.deletePolicy }}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test-runner
+      image: ubuntu
+      command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "----- Install dependencies -----"
+          apt-get update
+          apt-get -y install curl git
+          curl -o- $NVM_SCRIPT | bash
+          echo "----- Downloading $TEST_SCRIPT -----"
+          curl $TEST_SCRIPT --output /tmp/script.sh
+          echo "----- Running $TEST_SCRIPT -----"
+          bash -i /tmp/script.sh
+          set +e
+      env:
+        - name: NVM_SCRIPT
+          value: https://raw.githubusercontent.com/nvm-sh/nvm/{{ .Values.tests.api.nvm.version }}/install.sh
+        - name: TEST_SCRIPT
+          value: {{ tpl .Values.tests.api.script . }}
+        - name: GIT_URL
+          value: {{ tpl .Values.tests.api.git.url . }}
+        - name: GIT_TAG
+          value: {{ tpl .Values.tests.api.git.tag . }}
+        - name: TARGET_DIR
+          value: {{ tpl .Values.tests.api.targetDirectory . }}
+        - name: APP_ENDPOINT
+          value: {{ tpl .Values.tests.api.config.appEndpoint . }}
+        - name: APP_OAUTH_CLIENT_KEY
+          value: {{ tpl .Values.tests.api.config.appOauthClientKey . }}
+        - name: APP_OAUTH_CLIENT_SECRET
+          value: {{ tpl .Values.tests.api.config.appOauthClientSecret . }}
+        - name: OAUTH2_ISSUER
+          value: {{ tpl .Values.tests.api.config.oauth2Issuer . }}
+{{- end}}

--- a/charts/connection-manager/values.yaml
+++ b/charts/connection-manager/values.yaml
@@ -180,9 +180,9 @@ tests:
       # MCM API URL e.g. http(s)://<host>:<port>/api 
       APP_ENDPOINT: 'http://{{ include "connection-manager.fullname" . }}-api:3001/api'
       # MCM OAuth Client Key
-      APP_OAUTH_CLIENT_KEY: ''
+      APP_OAUTH_CLIENT_KEY: '{{ .Values.api.oauth.secret }}'
       # MCM OAuth Client Secret
-      APP_OAUTH_CLIENT_SECRET: ''
+      APP_OAUTH_CLIENT_SECRET: '{{ .Values.api.oauth.key }}'
       # OAuth Issuer URL e.g. http(s)://<host>:<port>/oauth2/token
       # Note: `client_credentials` grant_type must be supported
-      OAUTH2_ISSUER: ''
+      OAUTH2_ISSUER: '{{ .Values.api.oauth.issuer }}'

--- a/charts/connection-manager/values.yaml
+++ b/charts/connection-manager/values.yaml
@@ -175,13 +175,14 @@ tests:
     targetDirectory: /tmp/tests
     nvm:
       version: v0.39.1
-    config:
+    # Configuration Ref: https://github.com/modusbox/connection-manager-api/tree/master/functional-tests#configuration
+    env:
       # MCM API URL e.g. http(s)://<host>:<port>/api 
-      appEndpoint: 'http://{{ include "connection-manager.fullname" . }}-api:3001/api'
+      APP_ENDPOINT: 'http://{{ include "connection-manager.fullname" . }}-api:3001/api'
       # MCM OAuth Client Key
-      appOauthClientKey: ''
+      APP_OAUTH_CLIENT_KEY: ''
       # MCM OAuth Client Secret
-      appOauthClientSecret: ''
+      APP_OAUTH_CLIENT_SECRET: ''
       # OAuth Issuer URL e.g. http(s)://<host>:<port>/oauth2/token
       # Note: `client_credentials` grant_type must be supported
-      oauth2Issuer: ''
+      OAUTH2_ISSUER: ''

--- a/charts/connection-manager/values.yaml
+++ b/charts/connection-manager/values.yaml
@@ -1,7 +1,8 @@
 api:
+  disabled: false
   image:
     name: ghcr.io/modusbox/connection-manager-api
-    version: 1.8.16
+    version: 1.8.17
   ports:
     containerPort: 3001
     nodePort: 31057
@@ -77,8 +78,9 @@ api:
     serviceAccountNameOverride: null
   rbac:
     enabled: true
-  disabled: false
+
 ui:
+  disabled: false
   image:
     name: ghcr.io/modusbox/connection-manager-ui
     version: 1.6.16
@@ -87,6 +89,9 @@ ui:
     nodePort: 31627
   oauth:
     enabled: "FALSE"
+
+migrations:
+  enabled: true
 
 db:
   user: mcm
@@ -157,3 +162,26 @@ config:
       "ST": "test",
       "L": "test"
     }
+
+tests:
+  api:
+    enabled: true
+    weight: -5
+    deletePolicy: before-hook-creation
+    script: 'https://raw.githubusercontent.com/modusbox/connection-manager-api/v{{ .Values.api.image.version }}/scripts/run-functional-tests.sh'
+    git:
+      url: https://github.com/modusbox/connection-manager-api.git
+      tag: 'v{{ .Values.api.image.version }}'
+    targetDirectory: /tmp/tests
+    nvm:
+      version: v0.39.1
+    config:
+      # MCM API URL e.g. http(s)://<host>:<port>/api 
+      appEndpoint: 'http://{{ include "connection-manager.fullname" . }}-api:3001/api'
+      # MCM OAuth Client Key
+      appOauthClientKey: ''
+      # MCM OAuth Client Secret
+      appOauthClientSecret: ''
+      # OAuth Issuer URL e.g. https://iskm.local/oauth2/token
+      # Note: that `client_credentials` grant_type must be supported
+      oauth2Issuer: ''

--- a/charts/connection-manager/values.yaml
+++ b/charts/connection-manager/values.yaml
@@ -182,6 +182,6 @@ tests:
       appOauthClientKey: ''
       # MCM OAuth Client Secret
       appOauthClientSecret: ''
-      # OAuth Issuer URL e.g. https://iskm.local/oauth2/token
+      # OAuth Issuer URL e.g. http(s)://<host>:<port>/oauth2/token
       # Note: `client_credentials` grant_type must be supported
       oauth2Issuer: ''

--- a/charts/connection-manager/values.yaml
+++ b/charts/connection-manager/values.yaml
@@ -183,5 +183,5 @@ tests:
       # MCM OAuth Client Secret
       appOauthClientSecret: ''
       # OAuth Issuer URL e.g. https://iskm.local/oauth2/token
-      # Note: that `client_credentials` grant_type must be supported
+      # Note: `client_credentials` grant_type must be supported
       oauth2Issuer: ''


### PR DESCRIPTION
test(jira/MBP-29): implement api for providing dfsp hostname and ip whitelist - https://modusbox.atlassian.net/browse/MBP-29
- added api-test-runner for connection-manager
- added configuration values for api-test-runner
- bumped connection-manager-version from v1.8.16 -> v1.8.17 (dep: https://github.com/modusbox/connection-manager-api/pull/47)
- bumped connection-manager chart
- added migrations.enabled config to enable/disable migrations cron-job